### PR TITLE
Use getTypeName() instead of receiver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - 'iojs'
+  - '5'
+  - '4'
   - '0.12'
   - '0.10'

--- a/index.js
+++ b/index.js
@@ -6,7 +6,15 @@ module.exports = function () {
 	var caller;
 
 	for (var i = 0; i < c.length; i++) {
-		if (c[i].receiver !== undefined) {
+		var hasReceiver;
+
+		try {
+			hasReceiver = c[i].getTypeName() !== null;
+		} catch (err) {
+			hasReceiver = c[i].receiver !== undefined;
+		}
+
+		if (hasReceiver) {
 			caller = i;
 			break;
 		}


### PR DESCRIPTION
As receiver is now a private property we can't see it in newer versions of Node.js so use getTypeName() instead.

I basically derived this from https://chromium.googlesource.com/v8/v8/+/4.3.49/src/messages.js?autodive=0%2F%2F#810 where we can see that `getTypeName` gets the type name (if any) of the receiver.