### PR TITLE
`global` typename is not a receiver

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ module.exports = () => {
 	let caller;
 
 	for (let i = 0; i < c.length; i++) {
-		const hasReceiver = c[i].getTypeName() !== null;
+		const typeName = c[i].getTypeName();
+		const hasReceiver = typeName !== null && typeName !== 'global';
 
 		if (hasReceiver) {
 			caller = i;


### PR DESCRIPTION
Not sure if it's a matter of my use case of of recent Node.js versions (I'm using v9.11.1), but I was getting an incorrect `global` callsite. By ignoring it so it's picked the next one, it's working correctly.